### PR TITLE
fix: handle star imports without crashing _is_module's glob

### DIFF
--- a/src/betsy/__init__.py
+++ b/src/betsy/__init__.py
@@ -50,7 +50,10 @@ class ImportVisitor(ast.NodeVisitor):
             # Absolute: from X.Y import Z — Z may be a submodule of X.Y; emit per-alias
             # so _is_module can distinguish submodule from attribute in get_imports.
             for alias in node.names:
-                self.imports.add((*module, alias.name))
+                if alias.name == "*":
+                    self.imports.add(module)
+                else:
+                    self.imports.add((*module, alias.name))
         else:
             package = self.base if self.is_package else self.base[:-1]
             index = len(package) - (node.level - 1)
@@ -61,7 +64,10 @@ class ImportVisitor(ast.NodeVisitor):
             else:
                 # from . import X, Y — each name may be a submodule or a re-exported name
                 for alias in node.names:
-                    self.imports.add((*package[:index], alias.name))
+                    if alias.name == "*":
+                        self.imports.add(package[:index])
+                    else:
+                        self.imports.add((*package[:index], alias.name))
 
 
 def _path_to_module_path(path: Path, root: Path) -> ModulePath:

--- a/tests/test_betsy.py
+++ b/tests/test_betsy.py
@@ -117,6 +117,22 @@ def test_visit_import_from_relative_no_module_multiple_names():
     assert visitor.imports == {("pkg", "sub", "mod_d"), ("pkg", "sub", "mod_e")}
 
 
+def test_visit_import_from_absolute_star():
+    # from pkg.sub import * — the "*" alias is not a real name, so it must not
+    # be appended as a fake module path component (regression: this used to
+    # produce ("pkg", "sub", "*"), which later crashed _is_module's glob).
+    visitor = ImportVisitor(base=("pkg", "mod_a"))
+    visitor.visit(__import__("ast").parse("from pkg.sub import *\n"))
+    assert visitor.imports == {("pkg", "sub")}
+
+
+def test_visit_import_from_relative_no_module_star():
+    # from . import * — same as above but for the no-module relative form.
+    visitor = ImportVisitor(base=("pkg", "sub"), is_package=True)
+    visitor.visit(__import__("ast").parse("from . import *\n"))
+    assert visitor.imports == {("pkg", "sub")}
+
+
 def test_visit_import_from_invalid_level_raises():
     visitor = ImportVisitor(base=("pkg", "mod_a"), is_package=False)
     with pytest.raises(AssertionError):
@@ -216,6 +232,22 @@ def test_get_imports_absolute_non_module_name_falls_back_to_parent(pkg_root: Pat
     (pkg_root / "consumer.py").write_text("from pkg.mod_b import SomeClass\n")
     imports = get_imports(pkg_root / "consumer.py", pkg_root)
     assert imports == {"pkg.mod_b"}
+
+
+def test_get_imports_star_import_does_not_crash(pkg_root: Path):
+    # Regression: "from X import *" produces an ast.alias(name="*"); this used
+    # to be appended verbatim as a module path component, so _is_module's
+    # glob("*<name>*.so") became glob("**.so") and raised
+    # ValueError("Invalid pattern: '**' can only be an entire path component").
+    (pkg_root / "consumer.py").write_text("from pkg.mod_b import *\n")
+    imports = get_imports(pkg_root / "consumer.py", pkg_root)
+    assert imports == {"pkg.mod_b"}
+
+
+def test_get_imports_relative_star_import_does_not_crash(pkg_root: Path):
+    (pkg_root / "sub" / "consumer.py").write_text("from . import *\n")
+    imports = get_imports(pkg_root / "sub" / "consumer.py", pkg_root)
+    assert imports == {"pkg.sub"}
 
 
 def test_get_imports_native_extension_via_pyi(pkg_root: Path):


### PR DESCRIPTION
`from X import *` and `from . import *` produce an ast.alias(name="*"), which was appended verbatim as a module path component. That path could reach _is_module's base.parent.glob(f"{base.name}*.so") as the pattern "**.so", which pathlib rejects since ** must be an entire path component. Star imports now resolve to a dependency on the module/package itself.