### PR TITLE
feat: modularity metrics

### DIFF
--- a/src/betsy/__init__.py
+++ b/src/betsy/__init__.py
@@ -194,6 +194,11 @@ class DependencyGraph:
         return max(_.count(".") for _ in self.data)
 
 
+from betsy.metrics import ModuleMetrics, compute_metrics  # noqa: E402
+
+__all__ = ["DependencyGraph", "ModuleMetrics", "compute_metrics"]
+
+
 def main() -> None:
     argp = ArgumentParser(prog="betsy", description="Incy-wincy Python project dependencies crawler")
 

--- a/src/betsy/metrics.py
+++ b/src/betsy/metrics.py
@@ -1,0 +1,135 @@
+# This file is part of "betsy" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# Betsy is a Python static dependency visualiser tool.
+#
+# Copyright (c) 2022 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Robert Martin-style component coupling metrics for a :class:`~betsy.DependencyGraph`.
+
+These are exposed as a standalone, public API so that consumers of the
+library can compute afferent/efferent coupling, instability, abstractness
+and the (signed) distance from the main sequence without generating a
+visualisation.
+"""
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from betsy import DependencyGraph
+
+_ABSTRACT_BASE_NAMES = {"ABC", "ABCMeta", "Protocol"}
+_ABSTRACT_METHOD_DECORATOR_NAMES = {"abstractmethod", "abstractproperty", "abstractclassmethod", "abstractstaticmethod"}
+
+
+def _name_of(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _is_abstract_class(node: ast.ClassDef) -> bool:
+    if any(_name_of(base) in _ABSTRACT_BASE_NAMES for base in node.bases):
+        return True
+
+    for keyword in node.keywords:
+        if keyword.arg == "metaclass" and _name_of(keyword.value) == "ABCMeta":
+            return True
+
+    for child in node.body:
+        if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if any(_name_of(_) in _ABSTRACT_METHOD_DECORATOR_NAMES for _ in child.decorator_list):
+            return True
+
+    return False
+
+
+def _class_stats(source: str) -> tuple[int, int]:
+    """Return (total classes, abstract classes) defined at any nesting level."""
+    total = abstract = 0
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ClassDef):
+            total += 1
+            abstract += _is_abstract_class(node)
+    return total, abstract
+
+
+def _module_class_stats(module: str, root: Path) -> tuple[int, int]:
+    base = root.parent / Path(*module.split("."))
+    for candidate in (base / "__init__.py", base.with_suffix(".py")):
+        if candidate.is_file():
+            return _class_stats(candidate.read_text())
+    return 0, 0
+
+
+@dataclass(frozen=True)
+class ModuleMetrics:
+    """Coupling metrics for a single module.
+
+    Attributes:
+        ca: Afferent coupling -- number of modules in the graph that depend on this one.
+        ce: Efferent coupling -- number of modules this one depends on.
+        i: Instability, ``ce / (ca + ce)``. ``0.0`` for a module with no incoming or outgoing edges.
+        a: Abstractness, the fraction of classes defined in the module that are abstract.
+            ``0.0`` for a module with no classes.
+        d: Signed distance from the main sequence, ``a + i - 1``.
+            Ranges over ``[-1, 1]``. Negative values sit in the "zone of pain"
+            (concrete and stable); positive values sit in the "zone of
+            uselessness" (abstract and unstable).
+    """
+
+    name: str
+    ca: int
+    ce: int
+    i: float
+    a: float
+    d: float
+
+
+def compute_metrics(graph: DependencyGraph) -> dict[str, ModuleMetrics]:
+    """Compute :class:`ModuleMetrics` for every module in ``graph``.
+
+    Only modules that were actually parsed from source (i.e. keys of
+    ``graph.data``) get an entry: external/unresolved imports have no
+    class information to derive abstractness from.
+    """
+    afferent: dict[str, int] = {name: 0 for name in graph.data}
+    for importer, imports in graph.data.items():
+        for imported in imports:
+            if imported in afferent and imported != importer:
+                afferent[imported] += 1
+
+    metrics: dict[str, ModuleMetrics] = {}
+    for name, imports in graph.data.items():
+        ca = afferent[name]
+        # Only count dependencies on other modules in the graph: external
+        # (e.g. stdlib/third-party) imports carry no coupling information
+        # of their own, so including them would skew instability.
+        ce = len({_ for _ in imports if _ in graph.data} - {name})
+        i = ce / (ca + ce) if ca + ce else 0.0
+
+        total_classes, abstract_classes = _module_class_stats(name, graph.root)
+        a = abstract_classes / total_classes if total_classes else 0.0
+
+        metrics[name] = ModuleMetrics(name=name, ca=ca, ce=ce, i=i, a=a, d=a + i - 1)
+
+    return metrics

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,167 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+from betsy import DependencyGraph
+from betsy.metrics import ModuleMetrics, _is_abstract_class, compute_metrics
+
+
+def _classdef(source: str) -> ast.ClassDef:
+    (node,) = ast.parse(source).body
+    assert isinstance(node, ast.ClassDef)
+    return node
+
+
+# -- _is_abstract_class -------------------------------------------------------
+
+
+def test_is_abstract_class_plain():
+    assert _is_abstract_class(_classdef("class Foo:\n    pass\n")) is False
+
+
+def test_is_abstract_class_inherits_abc():
+    assert _is_abstract_class(_classdef("class Foo(ABC):\n    pass\n")) is True
+
+
+def test_is_abstract_class_inherits_module_qualified_abc():
+    assert _is_abstract_class(_classdef("class Foo(abc.ABC):\n    pass\n")) is True
+
+
+def test_is_abstract_class_inherits_protocol():
+    assert _is_abstract_class(_classdef("class Foo(Protocol):\n    pass\n")) is True
+
+
+def test_is_abstract_class_metaclass_abcmeta():
+    assert _is_abstract_class(_classdef("class Foo(metaclass=ABCMeta):\n    pass\n")) is True
+
+
+def test_is_abstract_class_has_abstractmethod():
+    source = "class Foo:\n    @abstractmethod\n    def bar(self): ...\n"
+    assert _is_abstract_class(_classdef(source)) is True
+
+
+def test_is_abstract_class_has_qualified_abstractmethod():
+    source = "class Foo:\n    @abc.abstractmethod\n    def bar(self): ...\n"
+    assert _is_abstract_class(_classdef(source)) is True
+
+
+def test_is_abstract_class_unrelated_base():
+    assert _is_abstract_class(_classdef("class Foo(Bar):\n    pass\n")) is False
+
+
+# -- compute_metrics -----------------------------------------------------------
+
+
+@pytest.fixture
+def pkg_root(tmp_path: Path) -> Path:
+    root = tmp_path.resolve()
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    # mod_a is depended upon by both mod_b and mod_c (high afferent coupling,
+    # no imports of its own -> stable) and defines one abstract class.
+    (pkg / "mod_a.py").write_text("from abc import ABC\n\nclass Base(ABC):\n    pass\n")
+    (pkg / "mod_b.py").write_text("import pkg.mod_a\n")
+    (pkg / "mod_c.py").write_text("import pkg.mod_a\n")
+    return pkg
+
+
+def test_compute_metrics_returns_entry_per_parsed_module(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+    assert metrics.keys() == graph.data.keys()
+
+
+def test_compute_metrics_afferent_efferent_coupling(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg.mod_a"].ca == 2
+    assert metrics["pkg.mod_a"].ce == 0
+    assert metrics["pkg.mod_b"].ca == 0
+    assert metrics["pkg.mod_b"].ce == 1
+
+
+def test_compute_metrics_instability_stable_module(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    # Depended upon by everyone, depends on nothing -> maximally stable.
+    assert metrics["pkg.mod_a"].i == 0.0
+
+
+def test_compute_metrics_instability_unstable_module(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    # Depends on something, nothing depends on it -> maximally unstable.
+    assert metrics["pkg.mod_b"].i == 1.0
+
+
+def test_compute_metrics_isolated_module_has_zero_instability(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg"].ca == 0
+    assert metrics["pkg"].ce == 0
+    assert metrics["pkg"].i == 0.0
+
+
+def test_compute_metrics_abstractness(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg.mod_a"].a == 1.0
+    assert metrics["pkg.mod_b"].a == 0.0
+
+
+def test_compute_metrics_module_with_no_classes_has_zero_abstractness(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg.mod_b"].a == 0.0
+
+
+def test_compute_metrics_signed_distance_from_main_sequence(pkg_root: Path):
+    graph = DependencyGraph(pkg_root)
+    metrics = compute_metrics(graph)
+
+    # a=1.0, i=0.0 -> d = 1 + 0 - 1 = 0 (on the main sequence)
+    assert metrics["pkg.mod_a"].d == pytest.approx(0.0)
+    # a=0.0, i=1.0 -> d = 0 + 1 - 1 = 0 (on the main sequence too)
+    assert metrics["pkg.mod_b"].d == pytest.approx(0.0)
+
+
+def test_compute_metrics_zone_of_pain(tmp_path: Path):
+    # Concrete (a=0) and stable (i=0, i.e. depended-upon, no deps) -> negative D.
+    root = tmp_path.resolve() / "pkg"
+    root.mkdir()
+    (root / "__init__.py").write_text("")
+    (root / "core.py").write_text("")
+    (root / "consumer.py").write_text("import pkg.core\n")
+
+    graph = DependencyGraph(root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg.core"].d < 0
+
+
+def test_compute_metrics_zone_of_uselessness(tmp_path: Path):
+    # Abstract (a=1) and unstable (i=1, i.e. no dependents, has deps) -> positive D.
+    root = tmp_path.resolve() / "pkg"
+    root.mkdir()
+    (root / "__init__.py").write_text("")
+    (root / "leaf.py").write_text("")
+    (root / "unused_abstract.py").write_text("from abc import ABC\nimport pkg.leaf\n\nclass Base(ABC):\n    pass\n")
+
+    graph = DependencyGraph(root)
+    metrics = compute_metrics(graph)
+
+    assert metrics["pkg.unused_abstract"].d > 0
+
+
+def test_module_metrics_is_frozen_dataclass():
+    metrics = ModuleMetrics(name="pkg", ca=0, ce=0, i=0.0, a=0.0, d=-1.0)
+    with pytest.raises(AttributeError):
+        metrics.ca = 1


### PR DESCRIPTION
We add modularity metrics to the API so that one can get standard metrics, like instability, abstractness, distance from main sequence from a dependency graph.